### PR TITLE
don't automatically make link file

### DIFF
--- a/DesktopNotifications.Windows/WindowsApplicationContext.cs
+++ b/DesktopNotifications.Windows/WindowsApplicationContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -33,19 +33,6 @@ namespace DesktopNotifications.Windows
             var aumid = appUserModelId ?? appName; //TODO: Add seeded bits to avoid collisions?
 
             SetCurrentProcessExplicitAppUserModelID(aumid);
-
-            using var shortcut = new ShellLink
-            {
-                TargetPath = mainModule.FileName,
-                Arguments = string.Empty,
-                AppUserModelID = aumid
-            };
-
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var startMenuPath = Path.Combine(appData, @"Microsoft\Windows\Start Menu\Programs");
-            var shortcutFile = Path.Combine(startMenuPath, $"{appName}.lnk");
-
-            shortcut.Save(shortcutFile);
 
             return new WindowsApplicationContext(appName, aumid);
         }


### PR DESCRIPTION
This PR is removing code that was automatically creating an item in the start menu called "{appName}.lnk". This is why, if you've built Manager locally, you will have a Speckle.Manager shortcut which points to your local build. In production, this code was creating the Manager.lnk.

Our current installer is creating a better shorcut, "Manager for Speckle.lnk", in a manager for speckle folder at the location `%appdata%\Microsoft\Windows\Start Menu\Programs\Manager for Speckle`. I guess this shortcut is being hidden by the other shortcut?

Testing locally, this change definitely stops the unwanted behavior of creating a non-descriptive Manager.lnk file. However, because this file was no being created by our installer, we may need to update our installer to remove this file because it will not happen automatically.